### PR TITLE
Major updates

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -26,16 +26,16 @@ func TestConfigFromFile(t *testing.T) {
 
 	// top level config values
 	if got, want := C.Port, 5002; got != want {
-		t.Error("got port %d, want %d", got, want)
+		t.Errorf("got port %d, want %d", got, want)
 	}
 	if got, want := C.ProxyHost, "apid.docker"; got != want {
-		t.Error("got proxy host %s, want %s", got, want)
+		t.Errorf("got proxy host %s, want %s", got, want)
 	}
 	if got, want := C.ProxyPort, 9092; got != want {
-		t.Error("got proxy port %d, want %d", got, want)
+		t.Errorf("got proxy port %d, want %d", got, want)
 	}
 	if got, want := C.ProxyDelayTime, time.Millisecond*3; got != want {
-		t.Error("got delay time of %s, want %s", got.String(), want.String())
+		t.Errorf("got delay time of %s, want %s", got.String(), want.String())
 	}
 
 	// fakes
@@ -46,57 +46,57 @@ func TestConfigFromFile(t *testing.T) {
 
 	// first fake
 	if got, want := C.Fakes[0].HyjackPath, "/api/settings.json"; got != want {
-		t.Error("got hyjack path %s, want %s", got, want)
+		t.Errorf("got hyjack path %s, want %s", got, want)
 	}
 	if got, want := len(C.Fakes[0].Methods), 0; got != want {
 		// must fatal to prevent nil reference panics below
 		t.Fatalf("got %d methods, want %d", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseBody, ""; got != want {
-		t.Error("got %s, want nothing", got)
+		t.Errorf("got %s, want nothing", got)
 	}
 	if got, want := C.Fakes[0].ResponseCode, 500; got != want {
-		t.Error("got response code %d, want %d", got, want)
+		t.Errorf("got response code %d, want %d", got, want)
 	}
 	if got, want := len(C.Fakes[0].ResponseHeaders), 0; got != want {
-		t.Error("got %d response headers, want %d", got, want)
+		t.Errorf("got %d response headers, want %d", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseTime, time.Duration(0); got != want {
-		t.Error("got resposne time %v, want %v", got, want)
+		t.Errorf("got resposne time %v, want %v", got, want)
 	}
 
 	// second fake
 	if got, want := C.Fakes[1].HyjackPath, "/api/functions.json"; got != want {
-		t.Error("got hyjack path %s, want %s", got, want)
+		t.Errorf("got hyjack path %s, want %s", got, want)
 	}
 	if got, want := len(C.Fakes[1].Methods), 2; got != want {
 		// must fatal to prevent nil reference panics below
 		t.Fatalf("got %d methods, want %d", got, want)
 	}
 	if got, want := C.Fakes[1].Methods[0], "GET"; got != want {
-		t.Errorf("got method %s, want %d", got, want)
+		t.Errorf("got method %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[1].Methods[1], "POST"; got != want {
-		t.Errorf("got method %s, want %d", got, want)
+		t.Errorf("got method %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[1].ResponseBody, `{"json":true}`; got != want {
-		t.Error("got body %s, want nothing", got)
+		t.Errorf("got body %s, want nothing", got)
 	}
 	if got, want := C.Fakes[1].ResponseCode, 201; got != want {
-		t.Error("got response code %d, want %d", got, want)
+		t.Errorf("got response code %d, want %d", got, want)
 	}
 	if got, want := len(C.Fakes[1].ResponseHeaders), 2; got != want {
 		// must fatal to prevent nil reverence panics below
 		t.Fatalf("got %d response headers, want %d", got, want)
 	}
 	if got, want := C.Fakes[1].ResponseHeaders[0], "Content-Type: application/json"; got != want {
-		t.Error("got header %s, want %s", got, want)
+		t.Errorf("got header %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[1].ResponseHeaders[1], "Cache-Control: max-age=3600"; got != want {
-		t.Error("got header %s, want %s", got, want)
+		t.Errorf("got header %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[1].ResponseTime, time.Millisecond*1015; got != want {
-		t.Error("got resposne time %v, want %v", got, want)
+		t.Errorf("got resposne time %v, want %v", got, want)
 	}
 }
 
@@ -104,15 +104,15 @@ func TestConfigFromParameters(t *testing.T) {
 	defaultHyjackTestSetup()
 
 	// flag parameters
-	var Port int = 5000
-	var ResponseCode int = 201
-	var ResponseTime time.Duration = time.Millisecond * 1015
-	var ResponseBody string = `{"json":true}`
-	var ResponseHeaders StringSlice = StringSlice{"Content-Type: application/json", "Cache-Control: max-age=3600"}
-	var Methods StringSlice = StringSlice{"GET", "POST"}
-	var HyjackPath string = "/api/functions.json"
-	var ProxyHost string = "apid.docker"
-	var ProxyPort int = 9092
+	var Port = 5000
+	var ResponseCode = 201
+	var ResponseTime = time.Millisecond * 1015
+	var ResponseBody = `{"json":true}`
+	var ResponseHeaders = StringSlice{"Content-Type: application/json", "Cache-Control: max-age=3600"}
+	var Methods = StringSlice{"GET", "POST"}
+	var HyjackPath = "/api/functions.json"
+	var ProxyHost = "apid.docker"
+	var ProxyPort = 9092
 	var ProxyDelayTime time.Duration
 	var IsRegex bool
 	var UseRequestURI bool
@@ -122,13 +122,13 @@ func TestConfigFromParameters(t *testing.T) {
 
 	// top level config values
 	if got, want := C.Port, 5000; got != want {
-		t.Error("got port %d, want %d", got, want)
+		t.Errorf("got port %d, want %d", got, want)
 	}
 	if got, want := C.ProxyHost, "apid.docker"; got != want {
-		t.Error("got proxy host %s, want %s", got, want)
+		t.Errorf("got proxy host %s, want %s", got, want)
 	}
 	if got, want := C.ProxyPort, 9092; got != want {
-		t.Error("got proxy port %d, want %d", got, want)
+		t.Errorf("got proxy port %d, want %d", got, want)
 	}
 
 	// fakes
@@ -138,36 +138,36 @@ func TestConfigFromParameters(t *testing.T) {
 	}
 
 	if got, want := C.Fakes[0].HyjackPath, "/api/functions.json"; got != want {
-		t.Error("got hyjack path %s, want %s", got, want)
+		t.Errorf("got hyjack path %s, want %s", got, want)
 	}
 	if got, want := len(C.Fakes[0].Methods), 2; got != want {
 		// must fatal to prevent nil reference panics below
 		t.Fatalf("got %d methods, want %d", got, want)
 	}
 	if got, want := C.Fakes[0].Methods[0], "GET"; got != want {
-		t.Errorf("got method %s, want %d", got, want)
+		t.Errorf("got method %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[0].Methods[1], "POST"; got != want {
-		t.Errorf("got method %s, want %d", got, want)
+		t.Errorf("got method %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseBody, `{"json":true}`; got != want {
-		t.Error("got body %s, want nothing", got)
+		t.Errorf("got body %s, want nothing", got)
 	}
 	if got, want := C.Fakes[0].ResponseCode, 201; got != want {
-		t.Error("got response code %d, want %d", got, want)
+		t.Errorf("got response code %d, want %d", got, want)
 	}
 	if got, want := len(C.Fakes[0].ResponseHeaders), 2; got != want {
 		// must fatal to prevent nil reverence panics below
 		t.Fatalf("got %d response headers, want %d", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseHeaders[0], "Content-Type: application/json"; got != want {
-		t.Error("got header %s, want %s", got, want)
+		t.Errorf("got header %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseHeaders[1], "Cache-Control: max-age=3600"; got != want {
-		t.Error("got header %s, want %s", got, want)
+		t.Errorf("got header %s, want %s", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseTime, time.Millisecond*1015; got != want {
-		t.Error("got resposne time %v, want %v", got, want)
+		t.Errorf("got resposne time %v, want %v", got, want)
 	}
 }
 
@@ -192,13 +192,13 @@ func TestConfigFromFileAndParameters(t *testing.T) {
 
 	// top level config values, config data overridden by parameters
 	if got, want := C.Port, 5001; got != want {
-		t.Error("got port %d, want %d", got, want)
+		t.Errorf("got port %d, want %d", got, want)
 	}
 	if got, want := C.ProxyHost, "apid2.docker"; got != want {
-		t.Error("got proxy host %s, want %s", got, want)
+		t.Errorf("got proxy host %s, want %s", got, want)
 	}
 	if got, want := C.ProxyPort, 9093; got != want {
-		t.Error("got proxy port %d, want %d", got, want)
+		t.Errorf("got proxy port %d, want %d", got, want)
 	}
 
 	// fakes
@@ -210,58 +210,58 @@ func TestConfigFromFileAndParameters(t *testing.T) {
 
 	// first fake
 	if got, want := C.Fakes[0].HyjackPath, "/api/settings.json"; got != want {
-		t.Error("got hyjack path %s, want %s", got, want)
+		t.Errorf("got hyjack path %s, want %s", got, want)
 	}
 	if got, want := len(C.Fakes[0].Methods), 0; got != want {
 		// must fatal to prevent nil reference panics below
 		t.Fatalf("got %d methods, want %d", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseBody, ""; got != want {
-		t.Error("got %s, want nothing", got)
+		t.Errorf("got %s, want nothing", got)
 	}
 	if got, want := C.Fakes[0].ResponseCode, 500; got != want {
-		t.Error("got response code %d, want %d", got, want)
+		t.Errorf("got response code %d, want %d", got, want)
 	}
 	if got, want := len(C.Fakes[0].ResponseHeaders), 0; got != want {
-		t.Error("got %d response headers, want %d", got, want)
+		t.Errorf("got %d response headers, want %d", got, want)
 	}
 	if got, want := C.Fakes[0].ResponseTime, time.Duration(0); got != want {
-		t.Error("got resposne time %v, want %v", got, want)
+		t.Errorf("got resposne time %v, want %v", got, want)
 	}
 
 	// second and third fake
 	for i := 1; i <= 2; i++ {
 		if got, want := C.Fakes[i].HyjackPath, "/api/functions.json"; got != want {
-			t.Error("got hyjack path %s, want %s", got, want)
+			t.Errorf("got hyjack path %s, want %s", got, want)
 		}
 		if got, want := len(C.Fakes[i].Methods), 2; got != want {
 			// must fatal to prevent nil reference panics below
 			t.Fatalf("got %d methods, want %d", got, want)
 		}
 		if got, want := C.Fakes[i].Methods[0], "GET"; got != want {
-			t.Errorf("got method %s, want %d", got, want)
+			t.Errorf("got method %s, want %s", got, want)
 		}
 		if got, want := C.Fakes[i].Methods[1], "POST"; got != want {
-			t.Errorf("got method %s, want %d", got, want)
+			t.Errorf("got method %s, want %s", got, want)
 		}
 		if got, want := C.Fakes[i].ResponseBody, `{"json":true}`; got != want {
-			t.Error("got body %s, want nothing", got)
+			t.Errorf("got body %s, want nothing", got)
 		}
 		if got, want := C.Fakes[i].ResponseCode, 201; got != want {
-			t.Error("got response code %d, want %d", got, want)
+			t.Errorf("got response code %d, want %d", got, want)
 		}
 		if got, want := len(C.Fakes[i].ResponseHeaders), 2; got != want {
 			// must fatal to prevent nil reverence panics below
 			t.Fatalf("got %d response headers, want %d", got, want)
 		}
 		if got, want := C.Fakes[i].ResponseHeaders[0], "Content-Type: application/json"; got != want {
-			t.Error("got header %s, want %s", got, want)
+			t.Errorf("got header %s, want %s", got, want)
 		}
 		if got, want := C.Fakes[i].ResponseHeaders[1], "Cache-Control: max-age=3600"; got != want {
-			t.Error("got header %s, want %s", got, want)
+			t.Errorf("got header %s, want %s", got, want)
 		}
 		if got, want := C.Fakes[i].ResponseTime, time.Millisecond*1015; got != want {
-			t.Error("got resposne time %v, want %v", got, want)
+			t.Errorf("got resposne time %v, want %v", got, want)
 		}
 	}
 }

--- a/hyjacking_test.go
+++ b/hyjacking_test.go
@@ -30,14 +30,14 @@ func defaultHyjackTestSetup() {
 
 	// flag parameters
 	var Port = 4333
-	var ResponseCode int = http.StatusTeapot
+	var ResponseCode = http.StatusTeapot
 	var ResponseTime time.Duration
-	var ResponseBody string = "hyjacked"
-	var ResponseHeaders StringSlice = StringSlice{"Cache-Control: max-age=3600"}
-	var Methods StringSlice = StringSlice{"GET"}
-	var HyjackPath string = "/bar"
-	var ProxyHost string = "127.0.0.1"
-	var ProxyPort int = 4332
+	var ResponseBody = "hyjacked"
+	var ResponseHeaders = StringSlice{"Cache-Control: max-age=3600"}
+	var Methods = StringSlice{"GET"}
+	var HyjackPath = "/bar"
+	var ProxyHost = "127.0.0.1"
+	var ProxyPort = 4332
 	var ProxyDelayTime time.Duration
 	var IsRegex bool
 	var UseRequestURI bool
@@ -116,9 +116,9 @@ func TestHyjacking(t *testing.T) {
 }
 func TestProxyBasedOnMethod(t *testing.T) {
 	defaultHyjackTestSetup()
-	t.Log(">> verify that only methods specified are hyjacked")
+	t.Log(">> verify that only methods specified are hyjacked (post is not specified, should be proxied)")
 	{
-		resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/bar", GlobalConfig.Port), "application/json", strings.NewReader(""))
+		resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/bar", GlobalConfig.Port), "application/json", strings.NewReader("body!"))
 		if err != nil {
 			t.Fatalf("error getting url from proxy service - %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -263,6 +263,10 @@ func defaultHandler(w http.ResponseWriter, r *http.Request) {
 			requestHyjacked = false
 			log.Println("unable to read X-Return-Code", err)
 		}
+		if code == 100 {
+			log.Println("code 100 hangs the stdlib. Adusting code to 101")
+			code++
+		}
 	}
 	if hdr := r.Header.Get("X-Return-Data"); hdr != "" {
 		requestHyjacked = true

--- a/main.go
+++ b/main.go
@@ -247,8 +247,6 @@ func defaultHandler(w http.ResponseWriter, r *http.Request) {
 		requestHyjacked = true
 		err = json.Unmarshal([]byte(hdr), &headers)
 		if err != nil {
-			// TODO: if not json, try to parse key:v\n (like how it is set in the config)
-			// if key:v, convert to var headers http.Header
 			requestHyjacked = false
 			log.Println("unable to read X-Return-Headers", err)
 		}

--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ func populateGlobalConfig(ConfigData []byte, Port int, ResponseCode int, Respons
 		fake.UseRequestURI = UseRequestURI
 		config.Fakes = append(config.Fakes, fake)
 
-	} else if len(ResponseHeaders) != 0 || HyjackPath != "" || ResponseCode != 0 || ResponseCode != 0 || ResponseTime != 0 || len(Methods) != 0 {
+	} else if len(ResponseHeaders) != 0 || HyjackPath != "" || ResponseCode != 0 || ResponseTime != 0 || len(Methods) != 0 {
 		// no config fakes; if we have any parameters, let's use them
 		log.Println("creating fake based on parameters")
 		fake := &Fake{}
@@ -265,7 +265,7 @@ func defaultHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		req = r
+		log.Println("setting scheme as ", scheme)
 		req.URL.Scheme = scheme
 		req.URL.Host = host
 	}


### PR DESCRIPTION
Previously, fakettp was unable to take over different post requests because it only inspected URLs. This would cause issues on "hyjacking" POST requests in general. Note: I thought "hyjacking" was a cute alteration of the word. Now I'm thinking that should be normal English. 

In addition to the ability to now take over POST requests by matching on a substring of the POST body, there will now be the ability to set X-Return-* headers that will adjust the delay, headers, response code, and/or response body. Note, if any of these are set (aside from delay), then no proxying will occur. It is an all-or-nothing kind of setting.

I think in a next version, we will expose the ability to use fakettp as a package to aid in tests, as opposed to currently, it has to be a live running binary. Not sure yet. 